### PR TITLE
Enable scrolling in checkout modal

### DIFF
--- a/src/components/checkout/CheckoutSheet.tsx
+++ b/src/components/checkout/CheckoutSheet.tsx
@@ -213,7 +213,7 @@ export default function CheckoutSheet({ isOpen, onClose }: CheckoutSheetProps) {
     <AnimatePresence>
       {isOpen && (
         <>
-          <motion.div
+         <motion.div
             className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40"
             onClick={onClose}
             initial={{ opacity: 0 }}
@@ -229,6 +229,7 @@ export default function CheckoutSheet({ isOpen, onClose }: CheckoutSheetProps) {
     p-0
     rounded-none
     shadow-none
+    overflow-y-auto
   "
   initial={{ y: '100%' }}
   animate={{ y: 0 }}


### PR DESCRIPTION
## Summary
- allow checkout sheet to scroll its contents

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Property 'bgColor' does not exist on type 'string | {...}'; 'Toast' is not exported etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68921085fe60832790dbed735808c8ba